### PR TITLE
Add cartopy and motuclient deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ xarray
 netCDF4
 matplotlib
 seaborn
+cartopy
+motuclient


### PR DESCRIPTION
## Summary
- add cartopy and motuclient packages to requirements.txt

## Testing
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6889c71981c083279764118efa6d3251