### PR TITLE
Update datetime to UTC-aware

### DIFF
--- a/currents_report.qmd
+++ b/currents_report.qmd
@@ -8,7 +8,7 @@ format:
 
 ```{python}
 import pandas as pd
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 ```
 
@@ -18,7 +18,7 @@ from pathlib import Path
 # Read schedule and determine window
 schedule = pd.read_csv('release_schedule_15min.csv')
 start = schedule['release_time'].min()
-start_date = datetime.now().strftime('%Y-%m-%d')
+start_date = datetime.now(timezone.utc).strftime('%Y-%m-%d')
 print(f"Using start date {start_date}")
 ```
 

--- a/download_cmems_currents.py
+++ b/download_cmems_currents.py
@@ -12,7 +12,7 @@ Copernicus Marine credentials. Optionally specify `SIM_START_DATE`
 
 import os
 import subprocess
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import pandas as pd
 
 # 1. Load release schedule
@@ -20,7 +20,10 @@ schedule = pd.read_csv("release_schedule_15min.csv")
 
 # 2. Determine time window
 start_time_str = schedule['release_time'].min()
-start_date_str = os.environ.get("SIM_START_DATE", datetime.utcnow().strftime("%Y-%m-%d"))
+start_date_str = os.environ.get(
+    "SIM_START_DATE",
+    datetime.now(timezone.utc).strftime("%Y-%m-%d")
+)
 start_datetime = datetime.strptime(f"{start_date_str} {start_time_str}", "%Y-%m-%d %H:%M:%S")
 end_datetime = start_datetime + timedelta(hours=72)
 


### PR DESCRIPTION
## Summary
- ensure `download_cmems_currents.py` uses timezone-aware `datetime`
- make `currents_report.qmd` display UTC start date

## Testing
- `python3 -m py_compile download_cmems_currents.py`


------
https://chatgpt.com/codex/tasks/task_e_6889d55786ac8327a4ece19f60051edc