### PR TITLE
Fix datetime parsing in trajectory analysis

### DIFF
--- a/trajectory_analysis.qmd
+++ b/trajectory_analysis.qmd
@@ -38,6 +38,10 @@ if traj_file.suffix == '.nc':
 else:
     df = pd.read_csv(traj_file)
 
+# Ensure the 'time' column is parsed as datetime so pandas .dt methods work
+if 'time' in df.columns:
+    df['time'] = pd.to_datetime(df['time'])
+
 df.head()
 ```
 


### PR DESCRIPTION
## Summary
- parse the `time` column as a datetime when loading trajectory data

## Testing
- `python -m compileall -q trajectory_analysis.qmd`
- `python - <<'EOF'
import pandas as pd, xarray as xr
from pathlib import Path
traj_file = next(Path('.').glob('*.csv'))
if traj_file.suffix == '.nc':
    ds = xr.open_dataset(traj_file)
    df = ds.to_dataframe().reset_index()
else:
    df = pd.read_csv(traj_file)
if 'time' in df.columns:
    df['time'] = pd.to_datetime(df['time'])
print(df['time'].dtype)
print(df.head())
EOF

------
https://chatgpt.com/codex/tasks/task_e_688d4604a9448327b5f02946e7818f31